### PR TITLE
Made optional S3 envs optional

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -91,9 +91,15 @@ Config::define('S3_UPLOADS_BUCKET', env('S3_UPLOADS_BUCKET'));
 Config::define('S3_UPLOADS_KEY', env('S3_UPLOADS_KEY'));
 Config::define('S3_UPLOADS_SECRET', env('S3_UPLOADS_SECRET'));
 Config::define('S3_UPLOADS_REGION', env('S3_UPLOADS_REGION'));
-Config::define('S3_UPLOADS_HTTP_CACHE_CONTROL', env('S3_UPLOADS_HTTP_CACHE_CONTROL'));
-Config::define('S3_UPLOADS_HTTP_EXPIRES', env('S3_UPLOADS_HTTP_EXPIRES'));
-Config::define('S3_UPLOADS_BUCKET_URL', env('S3_UPLOADS_BUCKET_URL'));
+if (env('S3_UPLOADS_HTTP_CACHE_CONTROL')) {
+    Config::define('S3_UPLOADS_HTTP_CACHE_CONTROL', env('S3_UPLOADS_HTTP_CACHE_CONTROL'));
+}
+if (env('S3_UPLOADS_HTTP_EXPIRES')) {
+    Config::define('S3_UPLOADS_HTTP_EXPIRES', env('S3_UPLOADS_HTTP_EXPIRES'));
+}
+if (env('S3_UPLOADS_BUCKET_URL')) {
+    Config::define('S3_UPLOADS_BUCKET_URL', env('S3_UPLOADS_BUCKET_URL'));
+}
 
 /**
  * Custom Settings


### PR DESCRIPTION
when S3_UPLOADS_HTTP_EXPIRES is unset, env(S3_UPLOADS_HTTP_EXPIRES) defaults to an empty string which makes it impossible to upload any files to S3