### PR TITLE
Fix S3 media preview on library page of Wordpress Admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Update package.json to update the WordPress branch you need.
 Then run:
 
 ```
-└> docker-compose run --rm scalingo-wordpress composer update
+└> docker-compose run --rm web composer update
 ```
 
 Run locally to test WordPress is working, then commit `composer.json` and `composer.lock`.
@@ -137,7 +137,7 @@ A Docker Compose file is available to run the WordPress locally. You first need
 to install the dependencies with:
 
 ```bash
-docker-compose run --rm composer install --prefer-source --no-interaction
+docker-compose run --rm composer install --prefer-source --no-interaction --ignore-platform-reqs
 ```
 
 Then start the Nginx:

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "roots/wordpress": "~5.5",
     "roots/wp-config": "1.0.0",
     "roots/wp-password-bcrypt": "1.0.0",
-    "humanmade/s3-uploads": "~2.2",
+    "humanmade/s3-uploads": "~3.0",
     "wp-cli/wp-cli" : "~2.4",
     "psy/psysh" : "~0.9",
     "ext-imagick": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b0200340744b1107e6761a7de072ad5f",
+    "content-hash": "3cf141ab63e742e0153dc3c931b05113",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -508,23 +508,33 @@
         },
         {
             "name": "humanmade/s3-uploads",
-            "version": "2.2.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/S3-Uploads.git",
-                "reference": "577886b941438793a5721bbbb6eddc6872ee73cb"
+                "reference": "8a1262d482366e57a02885818570db6685efad42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/S3-Uploads/zipball/577886b941438793a5721bbbb6eddc6872ee73cb",
-                "reference": "577886b941438793a5721bbbb6eddc6872ee73cb",
+                "url": "https://api.github.com/repos/humanmade/S3-Uploads/zipball/8a1262d482366e57a02885818570db6685efad42",
+                "reference": "8a1262d482366e57a02885818570db6685efad42",
                 "shasum": ""
             },
             "require": {
                 "aws/aws-sdk-php": "~3.18",
                 "composer/installers": "~1.0"
             },
+            "require-dev": {
+                "humanmade/psalm-plugin-wordpress": "^1.0",
+                "pcov/clobber": "^2.0",
+                "phpunit/phpunit": "7.5"
+            },
             "type": "wordpress-plugin",
+            "autoload": {
+                "classmap": [
+                    "./inc"
+                ]
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0+"
@@ -541,11 +551,7 @@
             "keywords": [
                 "wordpress"
             ],
-            "support": {
-                "issues": "https://github.com/humanmade/s3-uploads/issues",
-                "source": "https://github.com/humanmade/s3-uploads"
-            },
-            "time": "2020-07-08T12:09:08+00:00"
+            "time": "2021-07-30T15:42:32+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",
@@ -1179,7 +1185,8 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress/zipball/5.5.3"
+                "url": "https://api.github.com/repos/WordPress/WordPress/zipball/5.5.3",
+                "reference": "5.5.3"
             },
             "require": {
                 "php": ">=5.3.2",
@@ -2932,5 +2939,5 @@
         "ext-imagick": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/config/environments/production.php
+++ b/config/environments/production.php
@@ -12,5 +12,15 @@ define('S3_UPLOADS_SECRET', env('S3_UPLOADS_SECRET'));
 define('S3_UPLOADS_REGION', env('S3_UPLOADS_REGION'));
 define('S3_UPLOADS_ENDPOINT', env('S3_UPLOADS_ENDPOINT'));
 
+if (env('S3_UPLOADS_ENDPOINT')) {
+    $s3_endpoint = env('S3_UPLOADS_ENDPOINT');
+    $s3_bucket_name = env('S3_UPLOADS_BUCKET');
+    $parts = parse_url($s3_endpoint);
+    $bucket_url = $parts['scheme'] . "://" . $s3_bucket_name . "." . $parts['host'];
+
+    // Define the base bucket URL (without trailing slash)
+    define('S3_UPLOADS_BUCKET_URL', $bucket_url);
+}
+
 if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')
     $_SERVER['HTTPS'] = 'on';

--- a/config/environments/production.php
+++ b/config/environments/production.php
@@ -11,7 +11,7 @@ define('S3_UPLOADS_KEY', getenv('S3_UPLOADS_KEY'));
 define('S3_UPLOADS_SECRET', getenv('S3_UPLOADS_SECRET'));
 define('S3_UPLOADS_REGION', getenv('S3_UPLOADS_REGION'));
 define('S3_UPLOADS_ENDPOINT', getenv('S3_UPLOADS_ENDPOINT'));
-if (getenv('S3_UPLOADS_ENDPOINT') && getenv('S3_UPLOADS_BUCKET_URL') === false) {
+if (getenv('S3_UPLOADS_ENDPOINT') && getenv('S3_UPLOADS_BUCKET') && !getenv('S3_UPLOADS_BUCKET_URL')) {
     $s3_endpoint = getenv('S3_UPLOADS_ENDPOINT');
     $s3_bucket_name = getenv('S3_UPLOADS_BUCKET');
     $parts = parse_url($s3_endpoint);

--- a/config/environments/production.php
+++ b/config/environments/production.php
@@ -12,10 +12,10 @@ define('S3_UPLOADS_SECRET', getenv('S3_UPLOADS_SECRET'));
 define('S3_UPLOADS_REGION', getenv('S3_UPLOADS_REGION'));
 define('S3_UPLOADS_ENDPOINT', getenv('S3_UPLOADS_ENDPOINT'));
 if (getenv('S3_UPLOADS_ENDPOINT') && getenv('S3_UPLOADS_BUCKET') && !getenv('S3_UPLOADS_BUCKET_URL')) {
-    $s3_endpoint = getenv('S3_UPLOADS_ENDPOINT');
-    $s3_bucket_name = getenv('S3_UPLOADS_BUCKET');
-    $parts = parse_url($s3_endpoint);
-    $bucket_url = $parts['scheme'] . "://" . $s3_bucket_name . "." . $parts['host'];
+    $s3_uploads_endpoint = getenv('S3_UPLOADS_ENDPOINT');
+    $s3_uploads_bucket = getenv('S3_UPLOADS_BUCKET');
+    $parts = parse_url($s3_uploads_endpoint);
+    $bucket_url = $parts['scheme'] . "://" . $s3_uploads_bucket . "." . $parts['host'];
 
     // Define the base bucket URL (without trailing slash)
     define('S3_UPLOADS_BUCKET_URL', $bucket_url);

--- a/config/environments/production.php
+++ b/config/environments/production.php
@@ -6,21 +6,21 @@ define('SCRIPT_DEBUG', false);
 /** Disable all file modifications including updates and update notifications */
 define('DISALLOW_FILE_MODS', true);
 
-define('S3_UPLOADS_BUCKET', env('S3_UPLOADS_BUCKET'));
-define('S3_UPLOADS_KEY', env('S3_UPLOADS_KEY'));
-define('S3_UPLOADS_SECRET', env('S3_UPLOADS_SECRET'));
-define('S3_UPLOADS_REGION', env('S3_UPLOADS_REGION'));
-define('S3_UPLOADS_ENDPOINT', env('S3_UPLOADS_ENDPOINT'));
-define('S3_UPLOADS_BUCKET_URL', env('S3_UPLOADS_BUCKET_URL'));
-
-if (env('S3_UPLOADS_ENDPOINT') && env('S3_UPLOADS_BUCKET_URL') == '') {
-    $s3_endpoint = env('S3_UPLOADS_ENDPOINT');
-    $s3_bucket_name = env('S3_UPLOADS_BUCKET');
+define('S3_UPLOADS_BUCKET', getenv('S3_UPLOADS_BUCKET'));
+define('S3_UPLOADS_KEY', getenv('S3_UPLOADS_KEY'));
+define('S3_UPLOADS_SECRET', getenv('S3_UPLOADS_SECRET'));
+define('S3_UPLOADS_REGION', getenv('S3_UPLOADS_REGION'));
+define('S3_UPLOADS_ENDPOINT', getenv('S3_UPLOADS_ENDPOINT'));
+if (getenv('S3_UPLOADS_ENDPOINT') && getenv('S3_UPLOADS_BUCKET_URL') === false) {
+    $s3_endpoint = getenv('S3_UPLOADS_ENDPOINT');
+    $s3_bucket_name = getenv('S3_UPLOADS_BUCKET');
     $parts = parse_url($s3_endpoint);
     $bucket_url = $parts['scheme'] . "://" . $s3_bucket_name . "." . $parts['host'];
 
     // Define the base bucket URL (without trailing slash)
     define('S3_UPLOADS_BUCKET_URL', $bucket_url);
+} else {
+    define('S3_UPLOADS_BUCKET_URL', getenv('S3_UPLOADS_BUCKET_URL'));
 }
 
 if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')

--- a/config/environments/production.php
+++ b/config/environments/production.php
@@ -11,8 +11,9 @@ define('S3_UPLOADS_KEY', env('S3_UPLOADS_KEY'));
 define('S3_UPLOADS_SECRET', env('S3_UPLOADS_SECRET'));
 define('S3_UPLOADS_REGION', env('S3_UPLOADS_REGION'));
 define('S3_UPLOADS_ENDPOINT', env('S3_UPLOADS_ENDPOINT'));
+define('S3_UPLOADS_BUCKET_URL', env('S3_UPLOADS_BUCKET_URL'));
 
-if (env('S3_UPLOADS_ENDPOINT')) {
+if (env('S3_UPLOADS_ENDPOINT') && env('S3_UPLOADS_BUCKET_URL') == '') {
     $s3_endpoint = env('S3_UPLOADS_ENDPOINT');
     $s3_bucket_name = env('S3_UPLOADS_BUCKET');
     $parts = parse_url($s3_endpoint);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3'
+
 services:
-  scalingo-wordpress:
+  web:
     build: .
     volumes:
       - .:/app
@@ -44,7 +45,7 @@ services:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
       - .:/app
     depends_on:
-      - scalingo-wordpress
+      - web
 
   composer:
     image: composer:1

--- a/nginx.conf
+++ b/nginx.conf
@@ -21,7 +21,7 @@ server {
   location ~ \.php$ {
     try_files $uri =404;
     fastcgi_split_path_info ^(.+\.php)(/.+)$;
-    fastcgi_pass scalingo-wordpress:9000;
+    fastcgi_pass web:9000; # web is the Docker container name
     fastcgi_index index.php;
     include fastcgi_params;
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;


### PR DESCRIPTION
Fix #23 

Related to an issue from a customer

## Changelog
- Fix the preview of medias on library page of Wordpress Admin, related to s3 plugin configuration. See: https://github.com/humanmade/S3-Uploads/tree/3.0.3#url-rewrites
- Update `humanmade/s3-uploads` Wordpress plugin to 3.0.3
- Allow to customize `S3_UPLOADS_BUCKET_URL` from environment variable
- Use `getenv` (PHP builtin) instead of `env`

The documentation will be made in #22